### PR TITLE
Don't require an init service

### DIFF
--- a/definitions/tilestacherc.rb
+++ b/definitions/tilestacherc.rb
@@ -11,7 +11,9 @@ define :tilestacherc, :reload => :delayed do
     mode 0644
     source node[:tilestache][:config][:source_file]
     cookbook node[:tilestache][:config][:source_cookbook]
-    notifies :restart, 'service[tilestache]', params[:reload]
+    if node[:tilestache][:init_type]
+      notifies :restart, 'service[tilestache]', params[:reload]
+    end
     action :create
   end
 end

--- a/recipes/gunicorn.rb
+++ b/recipes/gunicorn.rb
@@ -7,8 +7,10 @@
 # All rights reserved - Do Not Redistribute
 #
 
-service 'tilestache' do
-  action :nothing
+if node[:tilestache][:init_type]
+  service 'tilestache' do
+    action :nothing
+  end
 end
 
 python_pip 'gunicorn' do
@@ -39,10 +41,12 @@ gunicorn_config "#{node[:tilestache][:gunicorn][:cfgbasedir]}/#{node[:tilestache
   worker_timeout      node[:tilestache][:gunicorn][:timeout]
   worker_class        node[:tilestache][:gunicorn][:worker_class]
   
-  case node[:tilestache][:supervisor]
-  when true
-    notifies :restart, 'supervisor_service[tilestache]', :delayed
-  else
-    notifies :restart, 'service[tilestache]', :delayed
+  if node[:tilestache][:init_type]
+    case node[:tilestache][:supervisor]
+    when true
+      notifies :restart, 'supervisor_service[tilestache]', :delayed
+    else
+      notifies :restart, 'service[tilestache]', :delayed
+    end
   end
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -58,11 +58,13 @@ end
 
 tilestacherc 'tilestache-config' do
   cookbook node[:tilestache][:config][:cookbook]
-  case node[:tilestache][:supervisor]
-  when true
-    notifies :restart, 'supervisor_service[tilestache]', :delayed
-  else
-    notifies :restart, 'service[tilestache]', :delayed
+  if node[:tilestache][:init_type]
+    case node[:tilestache][:supervisor]
+    when true
+      notifies :restart, 'supervisor_service[tilestache]', :delayed
+    else
+      notifies :restart, 'service[tilestache]', :delayed
+    end
   end
 end
 


### PR DESCRIPTION
We prefer to let foreman start gunicorn along with other services, on demand, so we set `node[:tilestache][:init_type]` to `false`. The commits below allow this to happen.
