### PR TITLE
Add python-redis

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -18,6 +18,7 @@ require 'json'
   python-shapely
   python-psycopg2
   python-memcache
+  python-redis
   python-modestmaps
   python-protobuf
 ).each do |p|


### PR DESCRIPTION
If we're going to install memcache, it's only fair that we also install redis.
