### PR TITLE
Use python-pil package instead of image

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,13 +19,12 @@
   python-redis
   python-modestmaps
   python-protobuf
+  python-pil
 ).each do |p|
   package p do
     action :install
   end
 end
-
-python_pip 'image'
 
 python_pip 'tilestache' do
   version node[:tilestache][:version]

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -13,14 +13,11 @@ describe 'tilestache::install' do
     python-redis
     python-modestmaps
     python-protobuf
+    python-pil
   ).each do |pkg|
     it "should install package #{pkg}" do
       expect(chef_run).to install_package pkg
     end
-  end
-
-  it 'should python_pip install image' do
-    expect(chef_run).to install_python_pip 'image'
   end
 
   # install method switch


### PR DESCRIPTION
The python-pil apt package installs the python Pillow package, a fork of
PIL. This is all that tilestache requires, without having to install any django
specific bits (which is what the image package includes).
